### PR TITLE
Add chemistry diffusion coefficients to global parameters

### DIFF
--- a/src/post_process/m_global_parameters.fpp
+++ b/src/post_process/m_global_parameters.fpp
@@ -144,6 +144,7 @@ module m_global_parameters
     integer :: c_idx                               !< Index of color function
     type(int_bounds_info) :: species_idx           !< Indexes of first & last concentration eqns.
     integer :: damage_idx                          !< Index of damage state variable (D) for continuum damage model
+    real(wp), allocatable, dimension(:) :: chem_diffusion_coeffs
     !> @}
 
     ! Cell Indices for the (local) interior points (O-m, O-n, 0-p).
@@ -761,6 +762,8 @@ contains
             species_idx%beg = sys_size + 1
             species_idx%end = sys_size + num_species
             sys_size = species_idx%end
+            allocate(chem_diffusion_coeffs(num_species))
+            chem_diffusion_coeffs = 0._wp
         else
             species_idx%beg = 1
             species_idx%end = 1
@@ -966,6 +969,10 @@ contains
             ! Deallocating the grid variables, only used for the 1D simulations,
             ! and containing the defragmented computational domain grid data
             deallocate (x_root_cb, x_root_cc)
+        end if
+
+        if (allocated(chem_diffusion_coeffs)) then
+            deallocate(chem_diffusion_coeffs)
         end if
 
         deallocate (proc_coords)

--- a/src/pre_process/m_global_parameters.fpp
+++ b/src/pre_process/m_global_parameters.fpp
@@ -169,6 +169,8 @@ module m_global_parameters
     integer :: perturb_sph_fluid    !< Fluid to be perturbed with perturb_sph flag
     real(wp), dimension(num_fluids_max) :: fluid_rho
 
+    real(wp), allocatable, dimension(:) :: chem_diffusion_coeffs
+
     logical :: elliptic_smoothing
     integer :: elliptic_smoothing_iters
 
@@ -880,6 +882,11 @@ contains
         chemxb = species_idx%beg
         chemxe = species_idx%end
 
+        if (chemistry) then
+            allocate(chem_diffusion_coeffs(num_species))
+            chem_diffusion_coeffs = 0._wp
+        end if
+
         call s_configure_coordinate_bounds(recon_type, weno_polyn, muscl_polyn, &
                                            igr_order, buff_size, &
                                            idwint, idwbuff, viscous, &
@@ -989,6 +996,10 @@ contains
             if (p > 0) then
                 deallocate (z_cc, z_cb)
             end if
+        end if
+
+        if (allocated(chem_diffusion_coeffs)) then
+            deallocate(chem_diffusion_coeffs)
         end if
 
         deallocate (proc_coords)


### PR DESCRIPTION
## Summary
- track species diffusion coefficients in pre- and post-process global parameters modules
- allocate and clean up chemistry diffusion coefficient arrays when chemistry is enabled

## Testing
- `cmake -S . -B build-pre -DMFC_PRE_PROCESS=ON -DMFC_POST_PROCESS=OFF -DMFC_SIMULATION=OFF -DMFC_MPI=OFF` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3fdc97a8832a860837b8d9190d92