### PR TITLE
Raise patch limit to 20 patches

### DIFF
--- a/src/common/m_constants.fpp
+++ b/src/common/m_constants.fpp
@@ -21,7 +21,7 @@ module m_constants
     integer, parameter :: fourier_rings = 5                       !< Fourier filter ring limit
     integer, parameter :: num_fluids_max = 10                     !< Maximum number of fluids in the simulation
     integer, parameter :: num_probes_max = 10                     !< Maximum number of flow probes in the simulation
-    integer, parameter :: num_patches_max = 10
+    integer, parameter :: num_patches_max = 20
     integer, parameter :: num_bc_patches_max = 10
     integer, parameter :: pathlen_max = 400
     integer, parameter :: nnode = 4    !< Number of QBMM nodes


### PR DESCRIPTION
## Summary
- Increase `num_patches_max` to support configurations with up to 20 patches

## Testing
- `./mfc.sh build -j $(nproc)` *(fails: Could not find a version that satisfies the requirement hatchling)*
- `./mfc.sh test -j $(nproc)` *(fails: Could not find a version that satisfies the requirement hatchling)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b7c03304832a8dd920d993ad49ae